### PR TITLE
Get autoit-mode working in Emacs 25

### DIFF
--- a/autoit-mode.el
+++ b/autoit-mode.el
@@ -498,5 +498,4 @@ name/parameters unless this length is exceeded.")
           (kill-buffer buffer))))))
 
 (provide 'autoit-mode)
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; autoit-mode.el ends here

--- a/autoit-mode.el
+++ b/autoit-mode.el
@@ -59,6 +59,8 @@
 ;;      defined in function and variable declarations, and all builtin
 ;;      function names, wherever they appear.
 
+(require 'cl-lib)
+
 (defconst autoit-font-lock-keywords-1
   (list
    (cons (concat "\\<\\(" (regexp-opt autoit-builtins t) "\\)\\>")
@@ -101,7 +103,7 @@
   "Syntax table for `autoit-mode'")
 
 (defun autoit-mode-jump-to-include-file (&rest args)
-  (find-file (first args) nil))
+  (find-file (cl-first args) nil))
 
 (defun imenu--sort-by-position (item1 item2)
   (< (if (consp (cdr item1)) (cadr item1) (cdr item1))
@@ -270,7 +272,7 @@ name/parameters unless this length is exceeded.")
                     (< (point) old))
           (let ((comma-old (point)))
             (if (equal (autoit-smie-forward-token) ",")
-                (incf pos)
+		(cl-incf pos)
               (goto-char comma-old))))
         (let* ((result (concat fun ": "))
                (par-seq (car fun-info))
@@ -278,7 +280,7 @@ name/parameters unless this length is exceeded.")
                start-idx end-idx
                start-doc)
           (dotimes (i (length par-seq))
-            (when (plusp i) (setq result (concat result ", ")))
+	    (when (cl-plusp i) (setq result (concat result ", ")))
             (when (= i pos) (setq start-idx (length result)))
             (setq result (concat result (elt par-seq i)))
             (when (= i pos) (setq end-idx (length result))))
@@ -355,7 +357,7 @@ name/parameters unless this length is exceeded.")
                    done
                    future-optional-par
                    optional-par)
-              (labels ((forward-ignore-square-brackets
+	      (cl-labels ((forward-ignore-square-brackets
                         ()
                         (let (done tok)
                           (while (not done)
@@ -390,12 +392,12 @@ name/parameters unless this length is exceeded.")
                                      (while (setq tok (pop rev-par-tokens))
                                        (cond ((equal tok "=")
                                               (push tok parts))
-                                             ((endp rev-par-tokens)
+					     ((cl-endp rev-par-tokens)
                                               (push tok parts))
                                              ((equal "=" (car rev-par-tokens))
                                               (push tok parts))
                                              (t (setq parts
-                                                      (list* " " tok parts)))))
+						      (cl-list* " " tok parts)))))
                                      (when optional-par
                                        (push "[" parts))
                                      parts))
@@ -478,19 +480,19 @@ name/parameters unless this length is exceeded.")
                                      (while (setq tok (pop rev-par-tokens))
                                        (cond ((equal tok "=")
                                               (push tok parts))
-                                             ((endp rev-par-tokens)
+					     ((cl-endp rev-par-tokens)
                                               (push tok parts))
                                              ((equal "=" (car rev-par-tokens))
                                               (push tok parts))
                                              (t (setq parts
-                                                      (list* " " tok parts)))))
+						      (cl-list* " " tok parts)))))
                                      parts))
                             reversed-parameters)))
                   (message "%S" (autoit-eldoc-make-entry
                                  file pos
-                                 (caddr info) (reverse reversed-parameters)
+				 (cl-caddr info) (reverse reversed-parameters)
                                  (cadr info)))
-                  (puthash (caddr info)
+		  (puthash (cl-caddr info)
                            (list (reverse reversed-parameters)
                                  (cadr info)
                                  'udf)

--- a/autoit-smie.el
+++ b/autoit-smie.el
@@ -1,5 +1,7 @@
 ;;; autoit-smie.el --- AutoIt navigation and indentation
 
+;; Version: 2017-07-28
+
 (require 'smie)
 
 (defconst autoit-reserved-word-list

--- a/autoit-smie.el
+++ b/autoit-smie.el
@@ -1,3 +1,5 @@
+;;; autoit-smie.el --- AutoIt navigation and indentation
+
 (require 'smie)
 
 (defconst autoit-reserved-word-list

--- a/autoit-smie.el
+++ b/autoit-smie.el
@@ -3,6 +3,7 @@
 ;; Version: 2017-07-28
 
 (require 'smie)
+(require 'cl-lib)
 
 (defconst autoit-reserved-word-list
   '("if" "then" "elseif" "else" "endif"
@@ -35,7 +36,7 @@
     (let ((result (downcase str)))
       (cond ((member result autoit-reserved-word-list)
              result)
-            ((and (plusp (length result)) (char-equal (elt result 0) ?\#))
+            ((and (cl-plusp (length result)) (char-equal (elt result 0) ?\#))
              ";preprocessor;")
             (t ";id;")))))
 
@@ -210,7 +211,7 @@
   (let (*autoit-smie-forward-eob*
         *autoit-smie-forward-bob*)
     (save-excursion
-      (do ((prev nil current)
+      (cl-do ((prev nil current)
            (current (save-excursion (autoit-smie-backward-token-internal (- (point))))
                     (autoit-smie-backward-token-internal (point))))
           ((or (null current) (equal current ";lf;"))
@@ -223,7 +224,7 @@
   (let (*autoit-smie-forward-eob*
         *autoit-smie-forward-bob*)
     (save-excursion
-      (do ((prev nil current)
+      (cl-do ((prev nil current)
            (current (save-excursion (autoit-smie-forward-token-internal (- (point))))
                     (autoit-smie-forward-token-internal (point))))
           ((or (null current) (equal current ";lf;"))
@@ -584,7 +585,7 @@
                           #'smie-blink-matching-open
                           to-add))
          (filtered-psih
-          (nconc (mapcan (lambda (h) (unless (member h to-remove) (list h)))
+          (nconc (cl-mapcan (lambda (h) (unless (member h to-remove) (list h)))
                          post-self-insert-hook)
                  (list to-add))))
     (setq post-self-insert-hook filtered-psih)))

--- a/autoit-smie.el
+++ b/autoit-smie.el
@@ -588,3 +588,4 @@
     (setq post-self-insert-hook filtered-psih)))
 
 (provide 'autoit-smie)
+;;; autoit-smie.el ends here


### PR DESCRIPTION
I switched the Common Lisp function calls to `cl-lib` since those functions are no longer defined by default. I added some packaging attributes that `package-upload-file` requires in Emacs 25.2.

Is this the right branch?  I see that the `add-comment-indent-hook` branch has more recent changes.  I could easily apply these changes to that branch or to both.